### PR TITLE
Implement postpaid and prepaid as option on both fixed and rolling billing schedules

### DIFF
--- a/config/schema/commerce_recurring.schema.yml
+++ b/config/schema/commerce_recurring.schema.yml
@@ -42,6 +42,3 @@ commerce_recurring.commerce_billing_schedule.plugin.rolling:
     unit:
       type: string
       label: Unit
-    billing_type:
-      type: string
-      label: Billing type

--- a/config/schema/commerce_recurring.schema.yml
+++ b/config/schema/commerce_recurring.schema.yml
@@ -11,6 +11,9 @@ commerce_recurring.commerce_billing_schedule.*:
     display_label:
       type: label
       label: 'Display label'
+    billing_type:
+      type: string
+      label: Billing type
     plugin:
       type: string
       label: 'Plugin'
@@ -39,3 +42,6 @@ commerce_recurring.commerce_billing_schedule.plugin.rolling:
     unit:
       type: string
       label: Unit
+    billing_type:
+      type: string
+      label: Billing type

--- a/src/Entity/BillingSchedule.php
+++ b/src/Entity/BillingSchedule.php
@@ -78,6 +78,13 @@ class BillingSchedule extends ConfigEntityBase implements BillingScheduleInterfa
   protected $display_label;
 
   /**
+   * The billing type, either 'prepaid' or 'postpaid'.
+   *
+   * @var string
+   */
+  protected $billing_type = 'postpaid';
+
+  /**
    * The plugin ID.
    *
    * @var string
@@ -184,6 +191,26 @@ class BillingSchedule extends ConfigEntityBase implements BillingScheduleInterfa
       $this->pluginCollection = new CommerceSinglePluginCollection($plugin_manager, $this->plugin, $this->configuration, $this->id);
     }
     return $this->pluginCollection;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getBillingType() {
+    return $this->billing_type;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setBillingType($billing_type) {
+    if (!in_array($billing_type, ['prepaid', 'postpaid'], TRUE)) {
+      throw new \InvalidArgumentException("Billing type can just be 'prepaid' and 'postpaid'.");
+    }
+ 
+    $this->billing_type = $billing_type;
+
+    return $this;
   }
 
 }

--- a/src/Entity/BillingSchedule.php
+++ b/src/Entity/BillingSchedule.php
@@ -43,6 +43,7 @@ use Drupal\Core\Config\Entity\ConfigEntityBase;
  *     "label",
  *     "display_label",
  *     "status",
+ *     "billing_type",
  *     "plugin",
  *     "configuration",
  *   },
@@ -89,7 +90,7 @@ class BillingSchedule extends ConfigEntityBase implements BillingScheduleInterfa
    *
    * @var string
    */
-  protected $plugin = 'noop';
+  protected $plugin = 'fixed';
 
   /**
    * The plugin configuration.
@@ -207,7 +208,7 @@ class BillingSchedule extends ConfigEntityBase implements BillingScheduleInterfa
     if (!in_array($billing_type, ['prepaid', 'postpaid'], TRUE)) {
       throw new \InvalidArgumentException("Billing type can just be 'prepaid' and 'postpaid'.");
     }
- 
+
     $this->billing_type = $billing_type;
 
     return $this;

--- a/src/Entity/BillingScheduleInterface.php
+++ b/src/Entity/BillingScheduleInterface.php
@@ -62,4 +62,21 @@ interface BillingScheduleInterface extends ConfigEntityInterface, EntityWithPlug
    */
   public function setPluginConfiguration(array $configuration);
 
+  /**
+   * Returns the billing type, either prepaid or postpaid.
+   *
+   * @return string
+   */
+  public function getBillingType();
+
+  /**
+   * Sets the billing type.
+   *
+   * @param string $billing_type
+   *   The billing type, either prepaid or postpaid.
+   *
+   * @return $this
+   */
+  public function setBillingType($billing_type);
+
 }

--- a/src/Form/BillingScheduleForm.php
+++ b/src/Form/BillingScheduleForm.php
@@ -102,6 +102,18 @@ class BillingScheduleForm extends CommercePluginEntityFormBase {
       '#plugin_id' => $plugin,
       '#default_value' => $plugin_configuration,
     ];
+  
+    $form['billing_type'] = [
+      '#type' => 'radios',
+      '#title' => $this->t('Billing type'),
+      '#options' => [
+        'prepaid' => $this->t('Prepaid'),
+        'postpaid' => $this->t('Postpaid'),
+      ],
+      '#default_value' => $this->entity->getBillingType(),
+    ];
+
+
     $form['status'] = [
       '#type' => 'radios',
       '#title' => $this->t('Status'),

--- a/src/Form/BillingScheduleForm.php
+++ b/src/Form/BillingScheduleForm.php
@@ -102,7 +102,7 @@ class BillingScheduleForm extends CommercePluginEntityFormBase {
       '#plugin_id' => $plugin,
       '#default_value' => $plugin_configuration,
     ];
-  
+
     $form['billing_type'] = [
       '#type' => 'radios',
       '#title' => $this->t('Billing type'),
@@ -112,7 +112,6 @@ class BillingScheduleForm extends CommercePluginEntityFormBase {
       ],
       '#default_value' => $this->entity->getBillingType(),
     ];
-
 
     $form['status'] = [
       '#type' => 'radios',

--- a/src/Plugin/Commerce/BillingSchedule/Fixed.php
+++ b/src/Plugin/Commerce/BillingSchedule/Fixed.php
@@ -17,7 +17,7 @@ class Fixed extends IntervalBase {
    * {@inheritdoc}
    */
   public function getFirstBillingCycle(DrupalDateTime $start_time) {
-    $start_time = clone $start_time;
+    $start_time = $this->determineFirstStartTime($start_time);
 
     switch ($this->configuration['unit']) {
       case 'hour':

--- a/src/Plugin/Commerce/BillingSchedule/IntervalBase.php
+++ b/src/Plugin/Commerce/BillingSchedule/IntervalBase.php
@@ -16,9 +16,9 @@ abstract class IntervalBase extends BillingScheduleBase {
    */
   public function defaultConfiguration() {
     return [
-      'number' => 1,
-      'unit' => 'month',
-    ] + parent::defaultConfiguration();
+        'number' => 1,
+        'unit' => 'month',
+      ] + parent::defaultConfiguration();
   }
 
   /**
@@ -109,6 +109,23 @@ abstract class IntervalBase extends BillingScheduleBase {
   public function getNextBillingCycle(BillingCycle $cycle) {
     // @todo Should we have some + / - second offset?
     return new BillingCycle($cycle->getEndDate(), $this->modifyTime($cycle->getEndDate(), $this->configuration['number'], $this->configuration['unit']));
+  }
+
+  /**
+   * Determines the initial start time, which depend on the billing type.
+   *
+   * @param \Drupal\Core\Datetime\DrupalDateTime $start_time
+   *   The start time.
+   *
+   * @return \Drupal\Core\Datetime\DrupalDateTime
+   *   The initial time.
+   */
+  protected function determineFirstStartTime(DrupalDateTime $start_time) {
+    $start_time = clone $start_time;
+    if ($this->getConfiguration()['billing_type'] === 'prepaid') {
+      $start_time = $this->modifyTime($start_time, $this->configuration['number'], $this->configuration['unit']);
+    }
+    return $start_time;
   }
 
 }

--- a/src/Plugin/Commerce/BillingSchedule/IntervalBase.php
+++ b/src/Plugin/Commerce/BillingSchedule/IntervalBase.php
@@ -3,6 +3,7 @@
 namespace Drupal\commerce_recurring\Plugin\Commerce\BillingSchedule;
 
 use Drupal\commerce_recurring\BillingCycle;
+use Drupal\commerce_recurring\Entity\BillingSchedule;
 use Drupal\Core\Datetime\DrupalDateTime;
 use Drupal\Core\Form\FormStateInterface;
 
@@ -16,9 +17,9 @@ abstract class IntervalBase extends BillingScheduleBase {
    */
   public function defaultConfiguration() {
     return [
-        'number' => 1,
-        'unit' => 'month',
-      ] + parent::defaultConfiguration();
+      'number' => 1,
+      'unit' => 'month',
+    ] + parent::defaultConfiguration();
   }
 
   /**
@@ -122,7 +123,8 @@ abstract class IntervalBase extends BillingScheduleBase {
    */
   protected function determineFirstStartTime(DrupalDateTime $start_time) {
     $start_time = clone $start_time;
-    if ($this->getConfiguration()['billing_type'] === 'prepaid') {
+    $billing_schedule = BillingSchedule::load($this->entityIdy);
+    if ($billing_schedule->getBillingType() === 'prepaid') {
       $start_time = $this->modifyTime($start_time, $this->configuration['number'], $this->configuration['unit']);
     }
     return $start_time;

--- a/src/Plugin/Commerce/BillingSchedule/Rolling.php
+++ b/src/Plugin/Commerce/BillingSchedule/Rolling.php
@@ -17,7 +17,7 @@ class Rolling extends IntervalBase {
    * {@inheritdoc}
    */
   public function getFirstBillingCycle(DrupalDateTime $start_time) {
-    $start_time = clone $start_time;
+    $start_time = $this->determineFirstStartTime($start_time);
 
     $end_date = clone $start_time;
     $end_date = $this->modifyTime($end_date, $this->configuration['number'], $this->configuration['unit']);

--- a/src/Plugin/Commerce/SubscriptionType/SubscriptionTypeBase.php
+++ b/src/Plugin/Commerce/SubscriptionType/SubscriptionTypeBase.php
@@ -134,6 +134,9 @@ abstract class SubscriptionTypeBase extends PluginBase implements SubscriptionTy
     $next_billing_cycle = $subscription->getBillingSchedule()->getPlugin()->getNextBillingCycle($current_billing_cycle);
 
     // Create the order for the next billing cycles.
+    // @todo Take into account the schedules changes. In case the next cycle
+    //   is changing, we need to switch now, so we don't end up with some lack
+    //   of consistency.
     $next_order = Order::create([
       'type' => 'recurring',
       'uid' => $subscription->getCustomerId(),

--- a/tests/src/Kernel/BillingScheduleTest.php
+++ b/tests/src/Kernel/BillingScheduleTest.php
@@ -36,6 +36,7 @@ class BillingScheduleTest extends KernelTestBase {
       'label' => 'Test label',
       'display_label' => 'Test customer label',
       'plugin' => 'test_plugin',
+      'billing_type' => 'prepaid',
       'configuration' => [
         'key' => 'value',
       ],
@@ -43,6 +44,7 @@ class BillingScheduleTest extends KernelTestBase {
 
     $billing_schedule = BillingSchedule::load('test_id');
     $this->assertEquals('test_id', $billing_schedule->id());
+    $this->assertEquals('prepaid', $billing_schedule->getBillingType());
     $this->assertEquals('Test label', $billing_schedule->label());
     $this->assertEquals('test_plugin', $billing_schedule->getPluginId());
     $this->assertEquals('Test customer label', $billing_schedule->getDisplayLabel());

--- a/tests/src/Kernel/Plugin/Commerce/BillingSchedule/FixedTest.php
+++ b/tests/src/Kernel/Plugin/Commerce/BillingSchedule/FixedTest.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\Tests\commerce_recurring\Plugin\Commerce\BillingSchedule;
 
+use Drupal\commerce_recurring\Entity\BillingSchedule;
 use Drupal\commerce_recurring\Plugin\Commerce\BillingSchedule\Fixed;
 use Drupal\Core\Datetime\DrupalDateTime;
 use Drupal\KernelTests\KernelTestBase;
@@ -20,10 +21,13 @@ class FixedTest extends KernelTestBase {
   public static $modules = ['commerce_recurring'];
 
   public function testFixed() {
+    BillingSchedule::create(['id' => 'test'])->save();
+
     // 1 hour
     $fixed = new Fixed([
       'number' => 1,
       'unit' => 'hour',
+      '_entity_id' => 'test',
     ], '', []);
 
     $date = new DrupalDateTime('2017-10-09T15:07:12');
@@ -40,6 +44,7 @@ class FixedTest extends KernelTestBase {
     $fixed = new Fixed([
       'number' => 5,
       'unit' => 'hour',
+      '_entity_id' => 'test',
     ], '', []);
 
     $date = new DrupalDateTime('2017-10-09T15:07:12');
@@ -56,6 +61,7 @@ class FixedTest extends KernelTestBase {
     $fixed = new Fixed([
       'number' => 1,
       'unit' => 'day',
+      '_entity_id' => 'test',
     ], '', []);
 
     $date = new DrupalDateTime('2017-10-09T15:07:12');
@@ -72,6 +78,7 @@ class FixedTest extends KernelTestBase {
     $fixed = new Fixed([
       'number' => 6,
       'unit' => 'day',
+      '_entity_id' => 'test',
     ], '', []);
 
     $date = new DrupalDateTime('2017-10-09T15:07:12');
@@ -88,6 +95,7 @@ class FixedTest extends KernelTestBase {
     $fixed = new Fixed([
       'number' => 2,
       'unit' => 'week',
+      '_entity_id' => 'test',
     ], '', []);
 
     $date = new DrupalDateTime('2017-10-09T15:07:12');
@@ -104,6 +112,7 @@ class FixedTest extends KernelTestBase {
     $fixed = new Fixed([
       'number' => 1,
       'unit' => 'month',
+      '_entity_id' => 'test',
     ], '', []);
 
     $date = new DrupalDateTime('2017-10-09T15:07:12');
@@ -120,6 +129,7 @@ class FixedTest extends KernelTestBase {
     $fixed = new Fixed([
       'number' => 2,
       'unit' => 'month',
+      '_entity_id' => 'test',
     ], '', []);
 
     $date = new DrupalDateTime('2017-10-09T15:07:12');
@@ -136,6 +146,7 @@ class FixedTest extends KernelTestBase {
     $fixed = new Fixed([
       'number' => 2,
       'unit' => 'year',
+      '_entity_id' => 'test',
     ], '', []);
 
     $date = new DrupalDateTime('2017-10-09T15:07:12');
@@ -150,10 +161,11 @@ class FixedTest extends KernelTestBase {
   }
 
   public function testPrepaidMultipleCycles() {
+    BillingSchedule::create(['id' => 'test', 'billing_type' => 'prepaid'])->save();
     $fixed = new Fixed([
       'number' => 1,
       'unit' => 'month',
-      'billing_type' => 'prepaid',
+      '_entity_id' => 'test',
     ], '', []);
 
     $date = new DrupalDateTime('2017-10-09T15:07:12');
@@ -162,24 +174,25 @@ class FixedTest extends KernelTestBase {
     $result3 = $fixed->getNextBillingCycle($result2);
     $result4 = $fixed->getNextBillingCycle($result3);
 
-    $this->assertEquals('2017-11-01', $result->getStartDateTime()->format('Y-m-d'));
-    $this->assertEquals('2017-12-01', $result->getEndDateTime()->format('Y-m-d'));
+    $this->assertEquals('2017-11-01', $result->getStartDate()->format('Y-m-d'));
+    $this->assertEquals('2017-12-01', $result->getEndDate()->format('Y-m-d'));
 
-    $this->assertEquals('2017-12-01', $result2->getStartDateTime()->format('Y-m-d'));
-    $this->assertEquals('2018-01-01', $result2->getEndDateTime()->format('Y-m-d'));
+    $this->assertEquals('2017-12-01', $result2->getStartDate()->format('Y-m-d'));
+    $this->assertEquals('2018-01-01', $result2->getEndDate()->format('Y-m-d'));
 
-    $this->assertEquals('2018-01-01', $result3->getStartDateTime()->format('Y-m-d'));
-    $this->assertEquals('2018-02-01', $result3->getEndDateTime()->format('Y-m-d'));
+    $this->assertEquals('2018-01-01', $result3->getStartDate()->format('Y-m-d'));
+    $this->assertEquals('2018-02-01', $result3->getEndDate()->format('Y-m-d'));
 
-    $this->assertEquals('2018-02-01', $result4->getStartDateTime()->format('Y-m-d'));
-    $this->assertEquals('2018-03-01', $result4->getEndDateTime()->format('Y-m-d'));
+    $this->assertEquals('2018-02-01', $result4->getStartDate()->format('Y-m-d'));
+    $this->assertEquals('2018-03-01', $result4->getEndDate()->format('Y-m-d'));
   }
 
   public function testPostpaidMultipleCycles() {
+    BillingSchedule::create(['id' => 'test', 'billing_type' => 'postpaid'])->save();
     $fixed = new Fixed([
       'number' => 1,
       'unit' => 'month',
-      'billing_cycle' => 'postpaid',
+      '_entity_id' => 'test',
     ], '', []);
 
     $date = new DrupalDateTime('2017-10-09T15:07:12');
@@ -188,19 +201,17 @@ class FixedTest extends KernelTestBase {
     $result3 = $fixed->getNextBillingCycle($result2);
     $result4 = $fixed->getNextBillingCycle($result3);
 
-    $this->assertEquals('2017-10-01', $result->getStartDateTime()->format('Y-m-d'));
-    $this->assertEquals('2017-11-01', $result->getEndDateTime()->format('Y-m-d'));
+    $this->assertEquals('2017-10-01', $result->getStartDate()->format('Y-m-d'));
+    $this->assertEquals('2017-11-01', $result->getEndDate()->format('Y-m-d'));
 
-    $this->assertEquals('2017-11-01', $result2->getStartDateTime()->format('Y-m-d'));
-    $this->assertEquals('2017-12-01', $result2->getEndDateTime()->format('Y-m-d'));
+    $this->assertEquals('2017-11-01', $result2->getStartDate()->format('Y-m-d'));
+    $this->assertEquals('2017-12-01', $result2->getEndDate()->format('Y-m-d'));
 
-    $this->assertEquals('2017-12-01', $result3->getStartDateTime()->format('Y-m-d'));
-    $this->assertEquals('2018-01-01', $result3->getEndDateTime()->format('Y-m-d'));
+    $this->assertEquals('2017-12-01', $result3->getStartDate()->format('Y-m-d'));
+    $this->assertEquals('2018-01-01', $result3->getEndDate()->format('Y-m-d'));
 
-    $this->assertEquals('2018-01-01', $result4->getStartDateTime()->format('Y-m-d'));
-    $this->assertEquals('2018-02-01', $result4->getEndDateTime()->format('Y-m-d'));
-    $this->assertEquals('2019-01-01', $result2->getStartDate()->format('Y-m-d'));
-    $this->assertEquals('2021-01-01', $result2->getEndDate()->format('Y-m-d'));
+    $this->assertEquals('2018-01-01', $result4->getStartDate()->format('Y-m-d'));
+    $this->assertEquals('2018-02-01', $result4->getEndDate()->format('Y-m-d'));
   }
 
 }

--- a/tests/src/Kernel/Plugin/Commerce/BillingSchedule/FixedTest.php
+++ b/tests/src/Kernel/Plugin/Commerce/BillingSchedule/FixedTest.php
@@ -149,4 +149,58 @@ class FixedTest extends KernelTestBase {
     $this->assertEquals('2021-01-01', $result2->getEndDate()->format('Y-m-d'));
   }
 
+  public function testPrepaidMultipleCycles() {
+    $fixed = new Fixed([
+      'number' => 1,
+      'unit' => 'month',
+      'billing_type' => 'prepaid',
+    ], '', []);
+
+    $date = new DrupalDateTime('2017-10-09T15:07:12');
+    $result = $fixed->getFirstBillingCycle($date);
+    $result2 = $fixed->getNextBillingCycle($result);
+    $result3 = $fixed->getNextBillingCycle($result2);
+    $result4 = $fixed->getNextBillingCycle($result3);
+
+    $this->assertEquals('2017-11-01', $result->getStartDateTime()->format('Y-m-d'));
+    $this->assertEquals('2017-12-01', $result->getEndDateTime()->format('Y-m-d'));
+
+    $this->assertEquals('2017-12-01', $result2->getStartDateTime()->format('Y-m-d'));
+    $this->assertEquals('2018-01-01', $result2->getEndDateTime()->format('Y-m-d'));
+
+    $this->assertEquals('2018-01-01', $result3->getStartDateTime()->format('Y-m-d'));
+    $this->assertEquals('2018-02-01', $result3->getEndDateTime()->format('Y-m-d'));
+
+    $this->assertEquals('2018-02-01', $result4->getStartDateTime()->format('Y-m-d'));
+    $this->assertEquals('2018-03-01', $result4->getEndDateTime()->format('Y-m-d'));
+  }
+
+  public function testPostpaidMultipleCycles() {
+    $fixed = new Fixed([
+      'number' => 1,
+      'unit' => 'month',
+      'billing_cycle' => 'postpaid',
+    ], '', []);
+
+    $date = new DrupalDateTime('2017-10-09T15:07:12');
+    $result = $fixed->getFirstBillingCycle($date);
+    $result2 = $fixed->getNextBillingCycle($result);
+    $result3 = $fixed->getNextBillingCycle($result2);
+    $result4 = $fixed->getNextBillingCycle($result3);
+
+    $this->assertEquals('2017-10-01', $result->getStartDateTime()->format('Y-m-d'));
+    $this->assertEquals('2017-11-01', $result->getEndDateTime()->format('Y-m-d'));
+
+    $this->assertEquals('2017-11-01', $result2->getStartDateTime()->format('Y-m-d'));
+    $this->assertEquals('2017-12-01', $result2->getEndDateTime()->format('Y-m-d'));
+
+    $this->assertEquals('2017-12-01', $result3->getStartDateTime()->format('Y-m-d'));
+    $this->assertEquals('2018-01-01', $result3->getEndDateTime()->format('Y-m-d'));
+
+    $this->assertEquals('2018-01-01', $result4->getStartDateTime()->format('Y-m-d'));
+    $this->assertEquals('2018-02-01', $result4->getEndDateTime()->format('Y-m-d'));
+    $this->assertEquals('2019-01-01', $result2->getStartDate()->format('Y-m-d'));
+    $this->assertEquals('2021-01-01', $result2->getEndDate()->format('Y-m-d'));
+  }
+
 }

--- a/tests/src/Kernel/Plugin/Commerce/BillingSchedule/RollingTest.php
+++ b/tests/src/Kernel/Plugin/Commerce/BillingSchedule/RollingTest.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\Tests\commerce_recurring\Plugin\Commerce\BillingSchedule;
 
+use Drupal\commerce_recurring\Entity\BillingSchedule;
 use Drupal\commerce_recurring\Plugin\Commerce\BillingSchedule\Rolling;
 use Drupal\Core\Datetime\DrupalDateTime;
 use Drupal\KernelTests\KernelTestBase;
@@ -20,10 +21,13 @@ class RollingTest extends KernelTestBase {
   public static $modules = ['commerce_recurring'];
 
   public function testRolling() {
+    BillingSchedule::create(['id' => 'test'])->save();
+    
     // 1 hour
     $fixed = new Rolling([
       'number' => 1,
       'unit' => 'hour',
+      '_entity_id' => 'test',
     ], '', []);
 
     $date = new DrupalDateTime('2017-10-09T15:07:12');
@@ -40,6 +44,7 @@ class RollingTest extends KernelTestBase {
     $fixed = new Rolling([
       'number' => 5,
       'unit' => 'hour',
+      '_entity_id' => 'test',
     ], '', []);
 
     $date = new DrupalDateTime('2017-10-09T15:07:12');
@@ -56,6 +61,7 @@ class RollingTest extends KernelTestBase {
     $fixed = new Rolling([
       'number' => 1,
       'unit' => 'day',
+      '_entity_id' => 'test',
     ], '', []);
 
     $date = new DrupalDateTime('2017-10-09T15:07:12');
@@ -72,6 +78,7 @@ class RollingTest extends KernelTestBase {
     $fixed = new Rolling([
       'number' => 6,
       'unit' => 'day',
+      '_entity_id' => 'test',
     ], '', []);
 
     $date = new DrupalDateTime('2017-10-09T15:07:12');
@@ -88,6 +95,7 @@ class RollingTest extends KernelTestBase {
     $fixed = new Rolling([
       'number' => 2,
       'unit' => 'week',
+      '_entity_id' => 'test',
     ], '', []);
 
     $date = new DrupalDateTime('2017-10-09T15:07:12');
@@ -104,6 +112,7 @@ class RollingTest extends KernelTestBase {
     $fixed = new Rolling([
       'number' => 1,
       'unit' => 'month',
+      '_entity_id' => 'test',
     ], '', []);
 
     $date = new DrupalDateTime('2017-10-09T15:07:12');
@@ -120,6 +129,7 @@ class RollingTest extends KernelTestBase {
     $fixed = new Rolling([
       'number' => 2,
       'unit' => 'month',
+      '_entity_id' => 'test',
     ], '', []);
 
     $date = new DrupalDateTime('2017-10-09T15:07:12');
@@ -136,6 +146,7 @@ class RollingTest extends KernelTestBase {
     $fixed = new Rolling([
       'number' => 2,
       'unit' => 'year',
+      '_entity_id' => 'test',
     ], '', []);
 
     $date = new DrupalDateTime('2017-10-09T15:07:12');
@@ -150,10 +161,11 @@ class RollingTest extends KernelTestBase {
   }
 
   public function testPrepaidMultipleCycles() {
+    BillingSchedule::create(['id' => 'test', 'billing_type' => 'prepaid'])->save();
     $fixed = new Rolling([
       'number' => 1,
       'unit' => 'month',
-      'billing_type' => 'prepaid',
+      '_entity_id' => 'test',
     ], '', []);
 
     $date = new DrupalDateTime('2017-10-09T15:07:12');
@@ -162,24 +174,25 @@ class RollingTest extends KernelTestBase {
     $result3 = $fixed->getNextBillingCycle($result2);
     $result4 = $fixed->getNextBillingCycle($result3);
 
-    $this->assertEquals('2017-11-09', $result->getStartDateTime()->format('Y-m-d'));
-    $this->assertEquals('2017-12-09', $result->getEndDateTime()->format('Y-m-d'));
+    $this->assertEquals('2017-11-09', $result->getStartDate()->format('Y-m-d'));
+    $this->assertEquals('2017-12-09', $result->getEndDate()->format('Y-m-d'));
 
-    $this->assertEquals('2017-12-09', $result2->getStartDateTime()->format('Y-m-d'));
-    $this->assertEquals('2018-01-09', $result2->getEndDateTime()->format('Y-m-d'));
+    $this->assertEquals('2017-12-09', $result2->getStartDate()->format('Y-m-d'));
+    $this->assertEquals('2018-01-09', $result2->getEndDate()->format('Y-m-d'));
 
-    $this->assertEquals('2018-01-09', $result3->getStartDateTime()->format('Y-m-d'));
-    $this->assertEquals('2018-02-09', $result3->getEndDateTime()->format('Y-m-d'));
+    $this->assertEquals('2018-01-09', $result3->getStartDate()->format('Y-m-d'));
+    $this->assertEquals('2018-02-09', $result3->getEndDate()->format('Y-m-d'));
 
-    $this->assertEquals('2018-02-09', $result4->getStartDateTime()->format('Y-m-d'));
-    $this->assertEquals('2018-03-09', $result4->getEndDateTime()->format('Y-m-d'));
+    $this->assertEquals('2018-02-09', $result4->getStartDate()->format('Y-m-d'));
+    $this->assertEquals('2018-03-09', $result4->getEndDate()->format('Y-m-d'));
   }
 
   public function testPostpaidMultipleCycles() {
+    BillingSchedule::create(['id' => 'test', 'billing_type' => 'postpaid'])->save();
     $fixed = new Rolling([
       'number' => 1,
       'unit' => 'month',
-      'billing_type' => 'postpaid',
+      '_entity_id' => 'test',
     ], '', []);
 
     $date = new DrupalDateTime('2017-10-09T15:07:12');
@@ -188,17 +201,17 @@ class RollingTest extends KernelTestBase {
     $result3 = $fixed->getNextBillingCycle($result2);
     $result4 = $fixed->getNextBillingCycle($result3);
 
-    $this->assertEquals('2017-10-09', $result->getStartDateTime()->format('Y-m-d'));
+    $this->assertEquals('2017-10-09', $result->getStartDate()->format('Y-m-d'));
     $this->assertEquals('2017-11-09', $result->getEndDate()->format('Y-m-d'));
 
     $this->assertEquals('2017-11-09', $result2->getStartDate()->format('Y-m-d'));
     $this->assertEquals('2017-12-09', $result2->getEndDate()->format('Y-m-d'));
 
-    $this->assertEquals('2017-12-09', $result3->getStartDateTime()->format('Y-m-d'));
-    $this->assertEquals('2018-01-09', $result3->getEndDateTime()->format('Y-m-d'));
+    $this->assertEquals('2017-12-09', $result3->getStartDate()->format('Y-m-d'));
+    $this->assertEquals('2018-01-09', $result3->getEndDate()->format('Y-m-d'));
 
-    $this->assertEquals('2018-01-09', $result4->getStartDateTime()->format('Y-m-d'));
-    $this->assertEquals('2018-02-09', $result4->getEndDateTime()->format('Y-m-d'));
+    $this->assertEquals('2018-01-09', $result4->getStartDate()->format('Y-m-d'));
+    $this->assertEquals('2018-02-09', $result4->getEndDate()->format('Y-m-d'));
   }
 
 }

--- a/tests/src/Kernel/Plugin/Commerce/BillingSchedule/RollingTest.php
+++ b/tests/src/Kernel/Plugin/Commerce/BillingSchedule/RollingTest.php
@@ -149,4 +149,56 @@ class RollingTest extends KernelTestBase {
     $this->assertEquals('2021-10-09', $result2->getEndDate()->format('Y-m-d'));
   }
 
+  public function testPrepaidMultipleCycles() {
+    $fixed = new Rolling([
+      'number' => 1,
+      'unit' => 'month',
+      'billing_type' => 'prepaid',
+    ], '', []);
+
+    $date = new DrupalDateTime('2017-10-09T15:07:12');
+    $result = $fixed->getFirstBillingCycle($date);
+    $result2 = $fixed->getNextBillingCycle($result);
+    $result3 = $fixed->getNextBillingCycle($result2);
+    $result4 = $fixed->getNextBillingCycle($result3);
+
+    $this->assertEquals('2017-11-09', $result->getStartDateTime()->format('Y-m-d'));
+    $this->assertEquals('2017-12-09', $result->getEndDateTime()->format('Y-m-d'));
+
+    $this->assertEquals('2017-12-09', $result2->getStartDateTime()->format('Y-m-d'));
+    $this->assertEquals('2018-01-09', $result2->getEndDateTime()->format('Y-m-d'));
+
+    $this->assertEquals('2018-01-09', $result3->getStartDateTime()->format('Y-m-d'));
+    $this->assertEquals('2018-02-09', $result3->getEndDateTime()->format('Y-m-d'));
+
+    $this->assertEquals('2018-02-09', $result4->getStartDateTime()->format('Y-m-d'));
+    $this->assertEquals('2018-03-09', $result4->getEndDateTime()->format('Y-m-d'));
+  }
+
+  public function testPostpaidMultipleCycles() {
+    $fixed = new Rolling([
+      'number' => 1,
+      'unit' => 'month',
+      'billing_type' => 'postpaid',
+    ], '', []);
+
+    $date = new DrupalDateTime('2017-10-09T15:07:12');
+    $result = $fixed->getFirstBillingCycle($date);
+    $result2 = $fixed->getNextBillingCycle($result);
+    $result3 = $fixed->getNextBillingCycle($result2);
+    $result4 = $fixed->getNextBillingCycle($result3);
+
+    $this->assertEquals('2017-10-09', $result->getStartDateTime()->format('Y-m-d'));
+    $this->assertEquals('2017-11-09', $result->getEndDate()->format('Y-m-d'));
+
+    $this->assertEquals('2017-11-09', $result2->getStartDate()->format('Y-m-d'));
+    $this->assertEquals('2017-12-09', $result2->getEndDate()->format('Y-m-d'));
+
+    $this->assertEquals('2017-12-09', $result3->getStartDateTime()->format('Y-m-d'));
+    $this->assertEquals('2018-01-09', $result3->getEndDateTime()->format('Y-m-d'));
+
+    $this->assertEquals('2018-01-09', $result4->getStartDateTime()->format('Y-m-d'));
+    $this->assertEquals('2018-02-09', $result4->getEndDateTime()->format('Y-m-d'));
+  }
+
 }


### PR DESCRIPTION
Based upon https://github.com/bojanz/commerce_recurring/pull/20

* [x] Implement postpost and prepaid of fixed billing schedules
* [x] Implement postpost and prepaid of rolling billing schedules
* [x] Add tests for both cases