### PR TITLE
Usage tracking

### DIFF
--- a/commerce_recurring.install
+++ b/commerce_recurring.install
@@ -13,18 +13,21 @@ function commerce_recurring_schema() {
         'unsigned' => TRUE,
         'not null' => TRUE,
       ],
-      'usage_type' => [
-        'description' => 'The usage type.',
+      'usage_group' => [
+        'description' => 'The usage group defined in the subscription class.', // @TODO: Work this out.
         'type' => 'varchar_ascii',
         'length' => 255,
         'not null' => TRUE,
-        'default' => '',
       ],
       'subscription_id' => [
         'description' => 'The subscription ID.',
         'type' => 'int',
         'not null' => TRUE,
-        'default' => 0,
+      ],
+      'product_variation_id' => [
+        'description' => 'The product variation ID for this record.',
+        'type' => 'int',
+        'not null' => TRUE,
       ],
       'quantity' => [
         'description' => 'The usage quantity.',
@@ -49,4 +52,6 @@ function commerce_recurring_schema() {
       'timing' => ['start', 'end'],
     ],
   ];
+
+  return $schema;
 }

--- a/src/Plugin/Commerce/UsageType/Counter.php
+++ b/src/Plugin/Commerce/UsageType/Counter.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace Drupal\commerce_recurring\Plugin\Commerce\UsageType;
+
+use Drupal\commerce_recurring\BillingCycle;
+use Drupal\Core\Datetime\DrupalDateTime;
+use Drupal\commerce_recurring\Usage\UsageRecord;
+
+class Counter extends UsageTypeBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function requiredSubscriptionTypeInterfaces() {
+    return [
+      '\Drupal\commerce_recurring\Usage\SubscriptionFreeUsageInterface',
+    ];
+  }
+
+  /**
+   * Counter usage just needs to be registered for the given start date. The
+   * end date argument (if any) is ignored.
+   */
+  public function addUsage($quantity, DrupalDateTime $start, DrupalDateTime $end = NULL) {
+    $end = $start;
+    $record = $this->storage->createRecord()
+      ->setSubscription($this->subscription)
+      ->setProductVariation($this->groupInfo['product_variation'])
+      ->setStartDate($start)
+      ->setEndDate($end)
+      ->setQuantity($quantity);
+
+    // Counter usage is simple. We set up the record and store it.
+    $this->storage->setRecords([$record]);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function currentUsage(BillingCycle $cycle) {
+    // @TODO: Figure out how to get the current cycle, if one exists.
+
+
+    /* @var \Drupal\commerce_recurring\Usage\UsageRecordInterface[]*/
+    $records = $this->usageHistory($cycle);
+    // Sum up the quantity of all records in the cycle.
+    $quantity = 0;
+    foreach ($records as $record) {
+      $quantity += $record->getQuantity();
+    }
+
+    return $quantity;
+  }
+
+  /**
+   * {@inheritdoc}
+   *
+   * @TODO: Define what a charge is and how to make one
+   * @TODO: Write the subscription history interface/class
+   */
+  public function getCharges(BillingCycle $cycle) {
+    // Add up all of the counter records, grouping by product variation ID in
+    // case someone decided to get fancy.
+    $records = $this->usageHistory($cycle);
+    foreach ($records as $record) {
+      $variationId = $record->getProductVariation()->id();
+      $variations[$variationId] = $record->getProductVariation();
+    }
+    // We only want a unique list of the available product variation IDs.
+    $variationIds = array_unique(array_keys($variations));
+
+    foreach ($histories as $history) {
+
+      $quantities = array_fill_keys($variationIds, 0);
+      foreach ($records as $record) {
+        // Check if this record belongs in this history.
+        if ($record->getStart() >= $history->getStart() && $record->getStart() <= $history->getEnd()) {
+          $id = $record->getProductVariation->id();
+          $quantities[$id] += $record->getQuantity();
+        }
+      }
+
+      // Now we have a set of quantities keyed by product. Use the license to
+      // get a free quantity for each.
+      foreach ($quantities as $variationId => $quantity) {
+        $freeQuantity = $this->subscription->getFreeQuantity($this->name, $history->getId(), $variations[$variationId]);
+        $quantities[$variationId] = max(0, $quantity - $freeQuantity);
+      }
+
+      // Add the variation-keyed quantity list to this history ID for later turning into charges.
+      $finalQuantities[$history->getId()] = $quantities;
+    }
+
+    // Now we generate charges.
+    $charges[] = [];
+
+    foreach ($finalQuantities as $historyId => $productQuantities) {
+      foreach ($productQuantities as $variationId => $quantity) {
+        $this->generateCharge($quantity, $variations[$variationId], $histories[$historyId]);
+      }
+    }
+
+    return $charges;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function generateCharge($quantity, $productVariation, $subscriptionHistory) {
+    // @TODO: Figure this part out! Yay.
+  }
+
+}

--- a/src/Plugin/Commerce/UsageType/Gauge.php
+++ b/src/Plugin/Commerce/UsageType/Gauge.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace Drupal\commerce_recurring\Plugin\Commerce\UsageType;
+
+use Drupal\commerce_recurring\BillingCycle;
+
+class Gauge extends UsageTypeBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function requiredSubscriptionTypeInterfaces() {
+    return [
+      '\Drupal\commerce_recurring\Usage\SubscriptionFreeUsageInterface',
+      '\Drupal\commerce_recurring\Usage\SubscriptionInitialUsageInterface',
+    ];
+  }
+
+  /**
+   * Gauge usage groups expect usage records to span the timespan of all
+   * active plan history entries within the billing cycle.
+   */
+  public function isComplete(BillingCycle $cycle) {
+    $records = $this->usageHistory($cycle)->fetchCycleRecords($this->name, $this->subscription, $cycle);
+
+    // Get the length of the cycle in seconds.
+    $cycleLength = $cycle->getEndTime()->diff($cycle->getStartTime())->format('s') + 1;
+
+    // Add up the length of each record. Note that we use usageHistory() here
+    // (instead of the storage fetch method) because we want the records which
+    // have already been massaged to start and end with the billing cycle start
+    // and end timestamps. Otherwise nothing would ever add up.
+    $recordLength = 0;
+    foreach ($records as $record) {
+      $recordLength += $record->getStart() - $record->getEnd() + 1;
+    }
+
+    // These should match for a gauge group.
+    //
+    // @TODO: Respect non-active subscription statuses once history is locked
+    // down.
+    return $cycleLength == $recordLength;
+  }
+
+  /**
+   * Figure out charges.
+   */
+  public function getCharges(BillingCycle $cycle) {
+
+  }
+
+  /**
+   * Gauge usage needs to make sure to move any overlapping records out of the
+   * way so that even bad code cannot deliberately violate the completeness
+   * rules.
+   */
+  public function addUsage($quantity, $start, $end = NULL) {
+    // Get all the raw records for this group and subscription.
+    $records = $this->storage->fetchCycleRecords($this->name, $this->subscription);
+
+    $newRecord = $this->storage->createRecord()
+      ->setSubscription($this->subscription)
+      ->setProductVariation($this->groupInfo['product_variation'])
+      ->setStartDate($start)
+      ->setEndDate($end)
+      ->setQuantity($quantity);
+
+    $startTime = $start->getTimestamp();
+    $endTime = $end->getTimestamp();
+
+    // We store arrays of records to update and delete.
+    $updates = [$newRecord];
+    $deletions = [];
+
+    foreach ($records as $record) {
+      // The first thing to do is find all records which overlap the new record
+      // somehow.
+      if (($record->getEnd() >= $startTime || $record->getEnd() === NULL) && $record->getStart() < $startTime) {
+        $record->setEnd($startTime - 1);
+        $updates[] = $record;
+      }
+
+      // What else we do to preserve sanity depends on whether this is a
+      // completed record or not.
+      if ($endTime === NULL) {
+        // The new record has no end. That means we merely to need to delete all
+        // other records which come after it, if any.
+        if ($record->getStart() >= $startTime) {
+          $deletions[] = $record;
+        }
+      }
+      else {
+        if ($record->getStart() >= $startTime && $record->getEnd <= $endTime) {
+          // This record has a start and end already. We delete records that are
+          // inside of it.
+          $deletions[] = $record;
+        }
+        elseif ($record->getStart() >= $startTime && $record->getEnd() > $endTime) {
+          $record->setStart($endTime + 1);
+          $updates[] = $record;
+        }
+      }
+    }
+
+    $this->storage->setRecords($updates);
+    $this->storage->deleteRecords($deletions);
+  }
+
+  /**
+   * Get the current usage for a billing cycle.
+   */
+  public function currentUsage(BillingCycle $cycle = NULL) {
+    // Figure out how to get the current cycle, if one exists.
+
+
+    /* @var \Drupal\commerce_recurring\Usage\UsageRecordInterface[]*/
+    $records = $this->storage->fetchCycleRecords($this->name, $this->subscription, $cycle);
+    // Get all the records for the cycle and take the most recent one.
+    $latest = NULL;
+    foreach ($records as $record) {
+      if (is_null($latest) || $record->getStart()->getTimestamp() > $latest->getStart()->getTimestamp()) {
+        $latest = $record;
+      }
+    }
+
+    if (!$latest) {
+      // No usage registered.
+      return 0;
+    }
+    else {
+      return $latest->getQuantity();
+    }
+  }
+
+
+  /**
+   * Fix up records when the subscription changes somehow.
+   */
+  public function onSubscriptionChange() {
+    // @TODO
+    //
+  }
+
+}
+

--- a/src/Plugin/Commerce/UsageType/UsageTypeBase.php
+++ b/src/Plugin/Commerce/UsageType/UsageTypeBase.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\commerce_recurring\Plugin\Commerce\UsageType;
 
-use Drupal\commerce_order\Entity\OrderInterface;
+use Drupal\commerce_recurring\BillingCycle;
 use Drupal\commerce_recurring\Entity\SubscriptionInterface;
 use Drupal\commerce_recurring\Usage\UsageRecordStorageInterface;
 
@@ -25,14 +25,14 @@ abstract class UsageTypeBase implements UsageTypeInterface {
    *
    * @var string
    */
-  protected $groupName;
+  protected $name;
 
   /**
    * The group definition/info.
    *
    * @var array
    */
-  protected $groupInfo;
+  protected $info;
 
   /**
    * The subscription entity which owns this instance of the usage group.
@@ -44,33 +44,92 @@ abstract class UsageTypeBase implements UsageTypeInterface {
   /**
    * Instantiate a new usage type plugin.
    */
-  public function __construct(UsageRecordStorageInterface $storage, $groupName, $groupInfo, SubscriptionInterface $subscription) {
+  public function __construct(UsageRecordStorageInterface $storage, $name, $info, SubscriptionInterface $subscription) {
     $this->storage = $storage;
-    $this->groupName = $groupName;
-    $this->groupInfo = $groupInfo;
+    $this->name = $name;
+    $this->info = $info;
+
+    // We have to make sure that the subscription implements the necessary
+    // interfaces to work with these usage groups.
+    //
+    // @see \Drupal\commerce_recurring\UsageTypeInterface::requiredSubscriptionInterfaces()
+    foreach ($this->requiredSubscriptionTypeInterfaces() as $interface) {
+      if (!($this->subscription->getType() instanceof $interface)) {
+        throw new \LogicException('Usage groups of type ' . static::class . ' can only be attached to subscription types which implement ' . $interface);
+      }
+    }
+
     $this->subscription = $subscription;
   }
 
   /**
-   * Arbitrary getter for properties, including group info.
+   * Get the subscription of this usage group.
+   *
+   * @return \Drupal\commerce_recurring\Entity\SubscriptionInterface
+   */
+  public function getSubscription() {
+    return $this->subscription;
+  }
+
+  /**
+   * Get the name of the usage group.
+   *
+   * @return string
+   */
+  public function getName() {
+    return $this->name;
+  }
+
+  /**
+   * Get a part of the usage group definition.
    *
    * @param string $property
    *   The property or group info key to get.
    */
-  public function __get($property) {
-    if (!empty($this->{$property})) {
-      return $this->{$property};
-    }
-    elseif (!empty($this->groupInfo[$property])) {
-      return $this->groupInfo[$property];
+  public function getInfo($property) {
+    if (!empty($this->info[$property])) {
+      return $this->info[$property];
     }
   }
 
   /**
    * The default behavior is for usage groups to not enforce change scheduling.
    */
-  public function enforceChangeScheduling($property, OrderInterface $order) {
+  public function enforceChangeScheduling($property, $oldValue, $newValue) {
     return FALSE;
+  }
+
+  /**
+   * The default behavior is to regard usage as complete. Usage types with
+   * remote storage or record completeness requirements override this method.
+   */
+  public function isComplete() {
+    return TRUE;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function usageHistory(BillingCycle $cycle) {
+    // Here we fetch the records from storage, and then massage them to line
+    // up with the start and end of the billing cycle.
+    $records = $this->storage->fetchCycleRecords($cycle);
+    $cycleStart = $cycle->getStartDate()->getTimestamp();
+    $cycleEnd = $cycle->getEndDate()->getTimestamp();
+
+    foreach ($records as $record) {
+      if ($record->getStart() < $cycleStart) {
+        $record->setStart($cycleStart);
+      }
+      if (is_null($record->getEnd()) || $record->getEnd() > $cycleEnd) {
+        $record->setEnd($cycleEnd);
+      }
+    }
+
+    // That's all we need to do here.
+    // @TODO: The original module had static caching for this...worth it?
+    // I don't know what the new D8 patterns for this are.
+    return $records;
   }
 }
 

--- a/src/Usage/SubscriptionFreeUsageInterface.php
+++ b/src/Usage/SubscriptionFreeUsageInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Drupal\commerce_recurring\Usage;
+
+use Drupal\commerce_recurring\BillingCycle;
+
+interface SubscriptionFreeUsageInterface {
+  /**
+   * Get the free quantity which corresponds to a given usage charge.
+   *
+   * This is required by both the Gauge and Counter usage type plugins.
+   * Subscription types which want to use usage groups but don't need this
+   * behavior can simply return 0 for all group names.
+   *
+   * @param string $usageGroup
+   *   The name of the usage group to which the proposed charge belongs.
+   *
+   * @param \Drupal\commerce_product\Entity\ProductVariationInterface $variation
+   *   The product variation of the proposed charge.
+   *
+   * @param \Drupal\commerce_recurring\SubscriptionHistoryInterface $history
+   *   The subscription history object that corresponds to the proposed charge.
+   *
+   * @return int
+   *   The free quantity to be deducted from the proposed charge.
+   */
+  public function getFreeQuantity($usageGroup, $variation, $history);
+}

--- a/src/Usage/SubscriptionInitialUsageInterface.php
+++ b/src/Usage/SubscriptionInitialUsageInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Drupal\commerce_recurring\Usage;
+
+use Drupal\commerce_recurring\BillingCycle;
+
+interface SubscriptionInitialUsageInterface {
+  /**
+   * Get the initial quantity which should be registered for the usage group.
+   *
+   * This is required by just the Gauge usage type for registering usage when
+   * a new subscription history modification is made or when the subscription
+   * is initially activated.
+   *
+   * @param string $usageGroup
+   *   The name of the usage group to which the proposed charge belongs.
+   *
+   * @param \Drupal\commerce_product\Entity\ProductVariationInterface $variation
+   *   The product variation of the proposed charge.
+   *
+   * @param \Drupal\commerce_recurring\SubscriptionHistoryInterface $history
+   *   The subscription history object that corresponds to the proposed charge.
+   *
+   * @return int
+   *   The free quantity to be deducted from the proposed charge.
+   */
+  public function getInitialUsage($usageGroup, $variation, $history);
+}

--- a/src/Usage/UsageRecordDatabase.php
+++ b/src/Usage/UsageRecordDatabase.php
@@ -1,0 +1,242 @@
+<?php
+
+namespace Drupal\commerce_recurring\Usage;
+
+use Drupal\Core\Datetime\DrupalDateTime;
+use Drupal\commerce_recurring\Entity\SubscriptionInterface;
+use Drupal\commerce_product\Entity\ProductVariationInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+
+class UsageRecordDatabase {
+
+  /**
+   * The ID of this usage record, if it has been saved to storage.
+   *
+   * @var int
+   */
+  protected $usage_id = NULL;
+
+  /**
+   * The name of the usage group to which this record belongs.
+   *
+   * @var string
+   */
+  protected $usage_group;
+
+  /**
+   * The ID of this record's subscription, if any.
+   *
+   * @var int
+   */
+  protected $subscription_id;
+
+  /**
+   * The ID of this record's product variation, if any.
+   *
+   * @var int
+   */
+  protected $product_variation_id;
+
+  /**
+   * The quantity of this record.
+   *
+   * @var int
+   */
+  protected $quantity;
+
+  /**
+   * The start timestamp of this record.
+   *
+   * @var \Drupal\Core\Datetime\DrupalDateTime
+   */
+  protected $start;
+
+  /**
+   * The end timestamp of this record.
+   *
+   * @var \Drupal\Core\Datetime\DrupalDateTime
+   */
+  protected $end;
+
+  /**
+   * The Drupal entity type manager. Used to load subscriptions and products
+   *   since these database records only store IDs.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $typeManager;
+
+  /**
+   * Get an array of values for easy insertion via the Drupal database layer.
+   *
+   * @return array
+   */
+  public function getDatabaseValues() {
+    return [
+      'usage_id' => $this->usage_id,
+      'usage_group' => $this->usage_group,
+      'subscription_id' => $this->subscription_id,
+      'product_variation_id' => $this->product_variation_id,
+      'quantity' => $this->quantity,
+      'start' => $this->start,
+      'end' => $this->end,
+    ];
+  }
+
+  /**
+   * Class-specific constructor which injects the storage service for use later.
+   *
+   * @param UsageRecordStorageDatabase $storage
+   *   The storage engine which created this record.
+   */
+  public function __construct(EntityTypeManager $typeManager) {
+    $this->typeManager = $typeManager;
+  }
+
+  /**
+   * Get the ID of this record in storage. Used to figure out inserts vs merges
+   * in the default database storage implementation.
+   *
+   * Note: There is no setter for the ID, this can only be set by the storage
+   * engine.
+   *
+   * @return int
+   */
+  public function getId() {
+    return $this->usage_id;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getGroupName() {
+    return $this->usage_group;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setGroupName($groupName) {
+    $this->usage_group = $groupName;
+
+    return $this;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getSubscription() {
+    $storage = $this->typeManager->getStorage('commerce_subscription');
+
+    return $storage->load($this->subscription_id);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setSubscription(SubscriptionInterface $subscription) {
+    $this->subscription_id = $subscription->id();
+
+    return $this;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getProductVariation() {
+    $storage = $this->typeManager->getStorage('commerce_product_variation');
+
+    return $storage->load($this->product_variation_id);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setProductVariation(ProductVariationInterface $variation) {
+    $this->product_variation_id = $variation->id();
+
+    return $this;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getQuantity() {
+    return (int) $this->quantity;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setQuantity($quantity) {
+    $this->quantity = (int) $quantity;
+
+    return $this;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getStartDate() {
+    return is_null($this->start) ? NULL : new DrupalDateTime($this->start);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setStartDate(DrupalDateTime $start) {
+    $this->start = $start->getTimestamp();
+
+    return $this;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getStart() {
+    return $this->start;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setStart($start) {
+    $this->start = $start;
+
+    return $this;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getEndDate() {
+    return is_null($this->end) ? NULL : new DrupalDateTime($this->end);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setEndDate(DrupalDateTime $end) {
+    $this->end = $end->getTimestamp();
+
+    return $this;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getEnd() {
+    return $this->end;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setEnd($end) {
+    $this->end = $end;
+
+    return $this;
+  }
+
+}
+

--- a/src/Usage/UsageRecordInterface.php
+++ b/src/Usage/UsageRecordInterface.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace Drupal\commerce_recurring\Usage;
+
+use Drupal\Core\Datetime\DrupalDateTime;
+use Drupal\commerce_recurring\Entity\SubscriptionInterface;
+use Drupal\commerce_product\Entity\ProductVariationInterface;
+
+interface UsageRecordInterface {
+
+  /**
+   * Get the group name to which this record belongs.
+   *
+   * @return string
+   */
+  public function getGroupName();
+
+  /**
+   * Set the group name to which this record belongs.
+   *
+   * @param string $groupName
+   *
+   * @return this
+   */
+  public function setGroupName($groupName);
+
+  /**
+   * Get the subscription with which this record is associated.
+   *
+   * @return \Drupal\commerce_recurring\Entity\SubscriptionInterface
+   */
+  public function getSubscription();
+
+  /**
+   * Set the subscription with which this record is associated.
+   *
+   * @param \Drupal\commerce_recurring\Entity\SubscriptionInterface $subscription
+   *
+   * @return self
+   */
+  public function setSubscription(SubscriptionInterface $subscription);
+
+  /**
+   * Get the product variation which this record will charge for.
+   *
+   * @return \Drupal\commerce_product\Entity\ProductVariationInterface
+   */
+  public function getProductVariation();
+
+  /**
+   * Set the product variation which this record will charge for.
+   *
+   * @param \Drupal\commerce_product\Entity\ProductVariationInterface $variation
+   *
+   * @return self
+   */
+  public function setProductVariation(ProductVariationInterface $variation);
+
+  /**
+   * Get the quantity of this record.
+   *
+   * @return int
+   */
+  public function getQuantity();
+
+  /**
+   * Set the quantity of this record.
+   *
+   * @param int $quantity
+   *
+   * @return self
+   */
+  public function setQuantity($quantity);
+
+    /**
+   * Get the start time of this record.
+   *
+   * @return \Drupal\Core\Datetime\DrupalDateTime
+   */
+  public function getStartDate();
+
+  /**
+   * Set the start time of this record.
+   *
+   * @param \Drupal\Core\Datetime\DrupalDateTime $start
+   *
+   * @return self
+   */
+  public function setStartDate(DrupalDateTime $start);
+
+  /**
+   * Get the start timestamp of this record.
+   *
+   * @return int
+   */
+  public function getStart();
+
+  /**
+   * Set the start timestamp of this record.
+   *
+   * @param int|NULL $start
+   *
+   * @return self
+   */
+  public function setStart($start);
+
+  /**
+   * Get the end time of this record.
+   *
+   * @return \Drupal\Core\Datetime\DrupalDateTime
+   */
+  public function getEndDate();
+
+  /**
+   * Set the end time of this record.
+   *
+   * @param \Drupal\Core\Datetime\DrupalDateTime $end
+   *
+   * @return self
+   */
+  public function setEndDate(DrupalDateTime $end);
+
+  /**
+   * Get the end timestamp of this record.
+   *
+   * @return int
+   */
+  public function getEnd();
+
+  /**
+   * Set the end timestamp of this record.
+   *
+   * @param int|NULL $end
+   *
+   * @return self
+   */
+  public function setEnd(DrupalDateTime $end);
+}
+

--- a/src/Usage/UsageRecordStorageDatabase.php
+++ b/src/Usage/UsageRecordStorageDatabase.php
@@ -1,14 +1,33 @@
 <?php
 
-namespace Drupal\commerce_recurring;
+namespace Drupal\commerce_recurring\Usage;
 
 use Drupal\Core\Database\Connection;
 use Drupal\Core\Database\DatabaseException;
+use Drupal\commerce_recurring\Entity\SubscriptionInterface;
+use Drupal\commerce_recurring\BillingCycle;
+use Drupal\Core\Database\StatementInterface;
+use PDO;
 
 /**
  * Provides the default database storage backend for usage records.
  */
 class UsageRecordStorageDatabase implements UsageRecordStorageInterface {
+
+  /**
+   * The table name to query from.
+   *
+   * @var string
+   */
+  protected $tableName = 'commerce_recurring_usage';
+
+  /**
+   * The usage record class to use.
+   *
+   * @var string
+   */
+  protected $recordClass = 'UsageRecordDatabase';
+
   /**
    * The database connection in use.
    *
@@ -21,68 +40,183 @@ class UsageRecordStorageDatabase implements UsageRecordStorageInterface {
    *
    * @param \Drupal\Core\Database\Connection $connection
    *   The database connection for usage record storage.
+   *
+   * @param string $recordClass
+   *   The fully-qualified name of the record class to be used.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $typeManager
+   *   The entity type manager service.
+   *
    */
-  public function __construct(Connection $connection) {
+  public function __construct(Connection $connection, $recordClass, $typeManager) {
     $this->connection = $connection;
+    $this->recordClass = $recordClass;
+    $this->typeManager = $typeManager;
   }
 
   /**
    * Fetch all records which pertain to a given group, subscription, and
    * recurring order.
    *
-   * @param string $group_name
+   * @param string $groupName
    *   The group name. Required.
    *
-   * @param int $subscription_id
+   * @param \Drupal\commerce_recurring\Entity\SubscriptionInterface $subscription
    *   The subscription. Optional.
    *
-   * @param int $order_id
-   *   The recurring order. Optional.
+   * @param \Drupal\commerce_recurring\BillingCycle $cycle
+   *   The billing cycle. Optional.
    */
-  protected function fetchRecords($group_name, $subscription_id = NULL, $order_id = NULL) {
+  public function fetchCycleRecords($groupName, SubscriptionInterface $subscription = NULL, BillingCycle $cycle = NULL) {
+    $query = $this->connection->select($this->tableName);
+    $query->condition('usage_group', $groupName);
+    if (!is_null($subscription)) {
+      $query->condition('subscription_id', $subscription->getIdentifier());
+    }
+    if (!is_null($cycle)) {
+      // To accurately get all records, we need to find any that overlap with
+      // the time period of the billing cycle.
+      $start = $cycle->getStartDate();
+      $end = $cycle->getEndDate();
 
+      // Since some usage records have no end, we need to search for any which
+      // end later than the cycle's start date or have no end.
+      $ends = $query->orConditionGroup()
+        ->condition('end', $start->format('U'), '>')
+        ->isNull('end');
+
+      // Combine that with a condition to find those which start earlier than
+      // the cycle's end date and we have everything we need.
+      $timing = $query->andConditionGroup()
+        ->condition('start', $end->format('U'), '<')
+        ->condition($ends);
+
+      // Et voila.
+      $query->condition($timing);
+    }
+
+    $query->addTag('commerce_recurring_usage');
+
+    $results = $query->execute();
+
+    if (!is_null($results)) {
+      return $this->createFromStorage($results);
+    }
+    else {
+      return [];
+    }
   }
 
   /**
-   * Run multiple storage operations while enforcing consistency.
+   * Factory method for turning raw records (from the database) into record
+   *   objects. Leverages PDO::FETCH_CLASS
    *
-   * @param array $operations
-   *   A list of operations, each consisting of a 2-element array composed of:
+   * @param array $raw
+   *   The raw records as associative arrays.
    *
-   *   1. A method name
-   *   2. A list of arguments
-   *
-   * @return void
+   * @return \Drupal\commerce_recurring\Usage\UsageRecordInterface[]
+   *   The usage record objects.
    */
-  public function doMultiple($operations) {
-    // @TODO: Open a transaction.
-    //
-    try {
-      // Run each operation.
-      foreach ($operations as $op) {
-        // The second element of the operation should be a list of arguments.
-        list($method, $args) = $op;
-        $this->$method(...$args);
-      }
+  public function createFromStorage(StatementInterface $results) {
+    $results->setFetchMode(PDO::FETCH_CLASS, $this->recordClass, [$this->typeManager]);
 
-      // Hopefully we're done here.
-      $transaction->commit();
-    }
-    catch (DatabaseException $e) {
-      // Something went wrong. Sad.
-      $transaction->rollback();
-      // Propagate the exception? Not sure.
-      // @TODO: Figure this out.
-      throw $e;
-    }
+    return $results->fetchAll();
+  }
+
+  /**
+   * Create a new usage record object shell. This injects the type manager
+   * service so the record can use it to fetch stuff.
+   */
+  public function createRecord() {
+    $recordClass = $this->recordClass;
+    // Syntax is a pain.
+    $record = new $recordClass($this->typeManager);
+
+    return $record;
   }
 
   /**
    * Insert a usage record.
    *
-   * @param mixed $record
+   * @param \Drupal\commerce_recurring\Usage\UsageRecordInterface[] $record
    *   The usage record to be inserted.
    */
+  public function setRecords(array $records) {
+    $txn = $this->connection->startTransaction();
 
+    $inserts = [];
+    $updates = [];
+    foreach ($records as $record) {
+      if ($record->getId()) {
+        // Records which already have an ID must be updated.
+        $updates[] = $record->getDatabaseValues();
+      }
+      else {
+        $inserts[] = $record->getDatabaseValues();
+      }
+    }
+
+    try {
+      if (!empty($updates)) {
+        foreach ($updates as $update) {
+          $count = $this->connection->update($this->tableName)
+            ->fields($update)
+            ->condition('usage_id', $update['usage_id'])
+            ->execute();
+
+          // The number of rows matched had damn well better be 1.
+          if ($count != 1) {
+            throw new \LogicException("Failed to update usage record $update[usage_id].");
+          }
+        }
+      }
+
+      if (!empty($inserts)) {
+        $query = $this->connection->insert($this->tableName);
+        foreach ($inserts as $insert) {
+          $query->values($insert);
+        }
+
+        // Unfortunately, we can't really check this to make sure the right
+        // number were inserted without a lot more magic. Maybe @TODO?
+        $query->execute();
+      }
+    }
+    catch (\Exception $e) {
+      // Roll this back.
+      $txn->rollback();
+      throw $e;
+    }
+
+    // We're done. Yay.
+    $txn->commit();
+  }
+
+  /**
+   * Delete one or more usage records.
+   *
+   * @param \Drupal\commerce_recurring\Usage\UsageRecordInterface[] $records
+   *   The usage records to be deleted.
+   */
+  public function deleteRecords(array $records) {
+    $txn = $this->connection->startTransaction();
+
+    try {
+      // Delete each record.
+      foreach ($records as $record) {
+        if ($record->getId()) {
+          $this->connection->delete($this->tableName)
+            ->condition('usage_id', $record->getId())
+            ->execute();
+        }
+      }
+    }
+    catch (\Exception $e) {
+      $txn->rollback();
+      throw $e;
+    }
+
+    // We're done. Yay.
+  }
 }
 

--- a/src/Usage/UsageRecordStorageInterface.php
+++ b/src/Usage/UsageRecordStorageInterface.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\commerce_recurring\Usage;
 
-use Drupal\commerce_recurring\Usage\UsageRecordInterface;
+use Drupal\commerce_recurring\BillingCycle;
 
 /**
  * Storage interface for usage records.
@@ -19,54 +19,33 @@ interface UsageRecordStorageInterface {
    * @param \Drupal\commerce_recurring\Entity\SubscriptionInterface
    *   The subscription.
    *
-   * @param \Drupal\commerce_order\Entity\OrderInterface
-   *   The recurring order.
+   * @param \Drupal\commerce_recurring\BillingCycle
+   *   The billing cycle.
+   *
+   * @return \Drupal\commerce_recurring\Usage\UsageRecordInterface[]
+   *   The usage records.
    */
-  public function fetchOrderRecords($group_name, $subscription, $order);
+  public function fetchCycleRecords($group_name, $subscription, $cycle);
 
   /**
-   * Fetch all records which pertain to a given group and subscription.
+   * Create or update one or more usage records.
    *
-   * @param string $group_name
-   *   The group name.
-   *
-   * @param \Drupal\commerce_recurring\Entity\SubscriptionInterface
-   *   The subscription.
-   */
-  public function fetchSubscriptionRecords($group_name, $subscription);
-
-  /**
-   * Create a usage record.
-   *
-   * @param \Drupal\commerce_recurring\Usage\UsageRecordInterface
-   *   The usage record to be created.
+   * @param \Drupal\commerce_recurring\Usage\UsageRecordInterface[]
+   *   The usage records to be created or updated.
    *
    * @return void
    */
-  public function createRecord(UsageRecordInterface $record);
+  public function setRecords(array $records);
 
   /**
-   * Update a usage record.
+   * Delete one or more usage records.
    *
-   * @param \Drupal\commerce_recurring\Usage\UsageRecordInterface
-   *   The usage record to be modified.
+   * @param \Drupal\commerce_recurring\Usage\UsageRecordInterface[]
+   *   The usage records to be created or updated.
    *
    * @return void
    */
-  public function modifyRecord(UsageRecordInterface $record);
+  public function deleteRecords(array $records);
 
-  /**
-   * Perform multiple usage operations in a consistent way, failing if one or
-   * more of the requested operations does not succeed.
-   *
-   * @param array $operations
-   *   A list of operations, each consisting of a 2-element array composed of:
-   *
-   *   1. A method name
-   *   2. A list of arguments
-   *
-   * @return void
-   */
-  public function doMultiple($operations);
 }
 


### PR DESCRIPTION
Usage groups in 1.x were an add-on to licenses which allowed additional information about the consumption of electronic resources to be tracked and charged for. The idea here was to allow more full-featured recurring billing, where a license represented not just one electronic resource but a subscription plan that tracked multiple elements. Common examples might include:

- Cell phone plans which track text messages, minutes used, or bandwidth consumption
- Metered billing for physical resources like utilities (i.e. power, gas, etc.)
- Consumption of server resources (storage, bandwidth, CPU time, etc.) for a hosting provider
- Customer ticketing or support systems which charge on a per-ticket basis
- Organization-level SaaS subscriptions that charge on a per-user basis

The attached patch is an initial attempt at working out this within the context of the new 2.x module. It has several components:

- The UsageType plugin type, which handles the creation of usage records and generating matching charges for them on the recurring order for a given subscription. Two default implementations are provided:
- Counter: Usage where all records are added up and charged together, optionally with free quantities depending on the subscription
- Gauge: Usage which tracks a level of consumption for a period of time, with each charge pro-rated against the time interval when consumption was at that level
- Future goal: A "field" usage type which handles usage on the basis of a field value on an entity rather than using separate storage.
- A default storage engine and record type which uses a custom Drupal database table. (We considered using entities for this, but it seemed too heavy.) The goal is for storage to ultimately be swappable, so an interface is defined. (The idea here is that one of the default UsageType plugins could be swapped to some other storage system which delivers the records already recorded there.)
- A UsageRecord class and interface which define the components of a usage record and is used to generate charges.
- The concept of a "usage group" which is defined on the subscription type. Usage groups leverage a particular UsageType plugin but are defined at the SubscriptionType level, usually with a particular name and product variation attached.
- A set of SubscriptionType add-on interfaces which allow a given subscription type to define custom behavior for its usage groups. A given subscription type might want to define different free or initial quantities based on the current subscription plan and these interfaces allow them to do so without storing callbacks in the plugin definition.

Open questions are:

- In the original 1.x implementation, usage groups depended heavily on license revisions. By using revisions, usage groups were able to conform to changes in the underlying subscription plan -- the code would load the appropriate license revision, get the usage group definitions (including things like the product, free/initial quantity, etc.) from the revision, and proceed with its normal logic. With subscriptions not using the revision system, it is an open question how to handle this. I went with the "subscription type implements custom interface and the usage type plugin passes the relevant information back to the interface method to determine per-group information" at Bojan's suggestion, but this is still up for debate -- as is whatever we're doing to track subscription history in general.

- We haven't decided on the complete charge logic, so I have avoided writing those methods until I'm more familiar. Based on the current code though, it should be apparent how to load the usage records for a particular usage group, subscription, and billing cycle combiation and generate charges from there. Feedback is welcome.

- As noted, the next move (other than writing tests) is to generate a field-based usage type. A usage group leveraging this UsageType plugin would (under the current model) be attached to a subscription type implementing something like a SubscriptionFieldUsageInterface. The method for this interface would be able to generate usage records based on the value of a particular field on the subscription or some other entity. The motivation for this is that in 1.x usage groups were not super-easy to use -- you had to write code to call the addUsage method somewhere. Allowing subscriptions to leverage the field system is an easy way to make a limited version of this functionality available with more Drupal-ism and less custom code required.